### PR TITLE
Fix compile error due to deprecated UIDevice uniqueIdentifier

### DIFF
--- a/route-me/MapView/Map/RMCloudMadeMapSource.m
+++ b/route-me/MapView/Map/RMCloudMadeMapSource.m
@@ -73,9 +73,9 @@ NSString * const RMCloudMadeAccessTokenRequestFailed = @"RMCloudMadeAccessTokenR
 	if([self readTokenFromFile])
 			return;
 	
+  NSUUID *uuid = [[UIDevice currentDevice] identifierForVendor];
 	NSString* url = [NSString stringWithFormat:@"%@/token/%@?userid=%u",CMTokenAuthorizationServer,accessKey,
-					[[UIDevice currentDevice].uniqueIdentifier hash]];
-
+					[uuid hash]];
 	
 	NSData* data = nil;
 	RMLog(@"%s, url = %@\n",__FUNCTION__,url);


### PR DESCRIPTION
Switch to using `[[UIDevice currentDevice] identifierForVendor]` instead.

Source: http://stackoverflow.com/a/6993440/112705